### PR TITLE
bug: 배포시 python3 내장 모듈 미확인 버그 수정

### DIFF
--- a/run.prod.sh
+++ b/run.prod.sh
@@ -1,2 +1,2 @@
 cp .env.prod .env
-uvicorn src.main:app --host 0.0.0.0
+python3 -m uvicorn src.main:app --host 0.0.0.0

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 cp .env.dev .env
-uvicorn src.main:app
+python3 -m uvicorn src.main:app


### PR DESCRIPTION
> GiveUsMoney/FanFixiv#18 참고

배포시 `uvicorn` 내장모듈 미확인으로 배포 중단됨. 